### PR TITLE
JPA 사용 로직 개선

### DIFF
--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthToken.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthToken.java
@@ -28,7 +28,7 @@ public class AuthToken {
         cal.setTime(date);
         return LocalDateTime.of(
             cal.get(Calendar.YEAR),
-            cal.get(Calendar.MONTH),
+            cal.get(Calendar.MONTH) + 1,
             cal.get(Calendar.DATE),
             cal.get(Calendar.HOUR),
             cal.get(Calendar.MINUTE),

--- a/src/main/java/com/nimble/server_spring/infra/security/CustomUserDetails.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/CustomUserDetails.java
@@ -28,6 +28,7 @@ public class CustomUserDetails implements OAuth2User, UserDetails, OidcUser {
     private final OauthProvider providerType;
     private final RoleType roleType;
     private final Collection<GrantedAuthority> authorities;
+    private final User user;
     private Map<String, Object> attributes;
 
     @Override
@@ -82,7 +83,8 @@ public class CustomUserDetails implements OAuth2User, UserDetails, OidcUser {
             user.getPassword(),
             user.getProviderType(),
             RoleType.USER,
-            Collections.singletonList(new SimpleGrantedAuthority(RoleType.USER.getCode()))
+            Collections.singletonList(new SimpleGrantedAuthority(RoleType.USER.getCode())),
+            user
         );
     }
 

--- a/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -30,6 +31,7 @@ public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
     private final TokenCookieFactory tokenCookieFactory;
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(
         HttpServletRequest request, HttpServletResponse response, Authentication authentication
     ) throws IOException {
@@ -53,6 +55,7 @@ public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
         JwtToken jwtToken = jwtTokenRepository.findOneByUserId(userId)
             .map(token -> token.reissue(accessToken, refreshToken))
             .orElseGet(() -> JwtToken.issue(accessToken, refreshToken, userId));
+        jwtTokenRepository.save(jwtToken);
 
         response.addCookie(
             tokenCookieFactory.createAccessTokenCookie(jwtToken.getAccessToken())

--- a/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
@@ -51,10 +51,9 @@ public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
             JwtTokenType.REFRESH
         );
 
-        Long userId = userDetails.getUserId();
-        JwtToken jwtToken = jwtTokenRepository.findOneByUserId(userId)
+        JwtToken jwtToken = jwtTokenRepository.findOneByUserId(userDetails.getUserId())
             .map(token -> token.reissue(accessToken, refreshToken))
-            .orElseGet(() -> JwtToken.issue(accessToken, refreshToken, userId));
+            .orElseGet(() -> JwtToken.issue(accessToken, refreshToken, userDetails.getUser()));
         jwtTokenRepository.save(jwtToken);
 
         response.addCookie(

--- a/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 @Slf4j
+@Transactional
 public class AuthService {
 
     private final JwtTokenRepository jwtTokenRepository;
@@ -71,7 +72,6 @@ public class AuthService {
             JwtTokenType.REFRESH
         );
 
-        JwtToken newJwtToken = jwtToken.reissue(newAccessToken, newRefreshToken);
-        return jwtTokenRepository.save(newJwtToken);
+        return jwtToken.reissue(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
@@ -35,19 +35,16 @@ public class JwtToken {
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
     private User user;
 
-    @Column(name = "user_id")
-    private Long userId;
-
     boolean equalsAccessToken(String accessToken) {
         return this.accessToken.equals(accessToken);
     }
 
-    public static JwtToken issue(AuthToken accessToken, AuthToken refreshToken, Long userId) {
+    public static JwtToken issue(AuthToken accessToken, AuthToken refreshToken, User user) {
         return builder()
             .accessToken(accessToken.getToken())
             .refreshToken(refreshToken.getToken())
             .expiresAt(refreshToken.getExpiresAt())
-            .userId(userId)
+            .user(user)
             .build();
     }
 

--- a/src/main/java/com/nimble/server_spring/modules/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/dto/response/LoginResponseDto.java
@@ -19,7 +19,7 @@ public class LoginResponseDto {
 
     public static LoginResponseDto fromJwtToken(JwtToken jwtToken) {
         return LoginResponseDto.builder()
-            .userId(jwtToken.getUserId())
+            .userId(jwtToken.getUser().getId())
             .accessToken(jwtToken.getAccessToken())
             .build();
     }

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
@@ -14,6 +14,7 @@ import com.nimble.server_spring.modules.meet.MeetMember;
 import com.nimble.server_spring.modules.meet.MeetMemberRepository;
 import com.nimble.server_spring.modules.user.User;
 import com.nimble.server_spring.modules.user.UserRepository;
+import jakarta.annotation.Nullable;
 import java.security.Principal;
 import java.util.Map;
 import java.util.Objects;
@@ -33,6 +34,7 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
@@ -40,6 +42,7 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @Controller
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class ChatController {
 
     private final SimpMessageSendingOperations template;
@@ -63,7 +66,6 @@ public class ChatController {
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_MEMBER_NOT_FOUND));
 
         meetMember.enterMeet();
-        meetMemberRepository.save(meetMember);
 
         Chat chat = Chat.builder()
             .chatType(ChatType.ENTER)
@@ -127,7 +129,6 @@ public class ChatController {
         }
 
         meetMember.leaveMeet();
-        meetMemberRepository.save(meetMember);
 
         Chat chat = Chat.builder()
             .chatType(ChatType.LEAVE)

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
@@ -75,7 +75,8 @@ public class ChatController {
             .build();
         chatRepository.save(chat);
 
-        headerAccessor.setSessionAttributes(Map.of("memberId", meetMember.getId()));
+        Optional.ofNullable(headerAccessor.getSessionAttributes())
+            .ifPresent(attributes -> attributes.put("memberId", meetMember.getId()));
         template.convertAndSend(
             "/subscribe/chat/meet/" + meetId,
             ChatResponseDto.fromChat(chat)

--- a/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
@@ -54,7 +54,7 @@ public class Meet {
     @JoinColumn(name = "host_id")
     private User host;
 
-    @OneToMany(mappedBy = "meet", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "meet", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MeetMember> meetMembers = new ArrayList<>();
 
@@ -64,8 +64,8 @@ public class Meet {
 
     public Optional<MeetMember> findMember(Long memberId) {
         return this.meetMembers.stream()
-                .filter(meetMember -> meetMember.getId().equals(memberId))
-                .findFirst();
+            .filter(meetMember -> meetMember.getId().equals(memberId))
+            .findFirst();
     }
 
     public void addMeetMember(MeetMember meetMember) {

--- a/src/main/java/com/nimble/server_spring/modules/user/UserService.java
+++ b/src/main/java/com/nimble/server_spring/modules/user/UserService.java
@@ -5,9 +5,11 @@ import com.nimble.server_spring.infra.error.ErrorCodeException;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;


### PR DESCRIPTION
JPA를 사용하는 로직 단의 코드를 개선합니다.
기존에는 영속성 컨텍스트의 영속성 관리 로직을 고려하지 않고 jpa단의 코드를 구성했습니다.
이로 인해 프록시, 변경 감지, 고아 객체 관리, cascade 등의 영속성 컨텍스트 기능을 충분히 사용하지 못했습니다.

이를 개선하여 영속성 컨텍스트의 기능을 최대한 활용하도록 변경했습니다.
또한 인증, 채팅 로직에서 존재하던 버그 일부를 수정했습니다.

- [x] 버그 수정
  - [x] 로그인이 제대로 되지 않는 버그 수정 (LocalDateTime - Callender 간의 불일치 문제)
  - [x] 토큰 재발급이 제대로 되지 않는 버그 수정 (Repository save 누락)
  - [x] 채팅 leave가 제대로 되지 않는 버그 수정 (HeadearAttribute 세팅이 제대로 되지 않음)
- [x] 영속성 컨텍스트의 변경 감지를 사용하도록 수정 (JwtToken, Meet, MeetMember, Chat)
- [x] 외래키 id를 직접 사용하는 대신, 연관 객체의 참조 기반으로 로직을 변경 (JwtToken - User)
- [x] orphanRemoval, cascade 적용 (Meet - MeetMember)