### PR TITLE
엔티티 정의 및 구조 개선

### DIFF
--- a/src/main/java/com/nimble/server_spring/infra/persistence/BaseEntity.java
+++ b/src/main/java/com/nimble/server_spring/infra/persistence/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.nimble.server_spring.infra.persistence;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @NotNull
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
@@ -40,9 +40,10 @@ public class AuthService {
 
         User user = User.builder()
             .email(localSignupDto.getEmail())
-            .nickname(localSignupDto.getNickname())
             .password(encodedPassword)
+            .nickname(localSignupDto.getNickname())
             .providerType(OauthProvider.LOCAL)
+            .providerId(null)
             .build();
 
         return userRepository.save(user);

--- a/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
@@ -1,6 +1,7 @@
 package com.nimble.server_spring.modules.auth;
 
 import com.nimble.server_spring.infra.jwt.AuthToken;
+import com.nimble.server_spring.infra.persistence.BaseEntity;
 import com.nimble.server_spring.modules.user.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -12,7 +13,8 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class JwtToken {
+@ToString(of = {"id", "accessToken", "refreshToken", "expiresAt"})
+public class JwtToken extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
@@ -4,36 +4,45 @@ import com.nimble.server_spring.infra.jwt.AuthToken;
 import com.nimble.server_spring.modules.user.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
-@EqualsAndHashCode(of = "id")
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JwtToken {
 
     @Id
     @GeneratedValue
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
+    @NotNull
     @NotBlank
     private String accessToken;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
+    @NotNull
     @NotBlank
     private String refreshToken;
 
-    @Column(nullable = false)
+    @NotNull
     private LocalDateTime expiresAt;
 
     @OneToOne
-    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    @JoinColumn(name = "user_id")
+    @NotNull
     private User user;
+
+    @Builder
+    public JwtToken(String accessToken, String refreshToken, LocalDateTime expiresAt, User user) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiresAt = expiresAt;
+        this.user = user;
+    }
 
     boolean equalsAccessToken(String accessToken) {
         return this.accessToken.equals(accessToken);

--- a/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
@@ -1,41 +1,26 @@
 package com.nimble.server_spring.modules.chat;
 
+import com.nimble.server_spring.infra.persistence.BaseEntity;
 import com.nimble.server_spring.modules.meet.Meet;
 import com.nimble.server_spring.modules.meet.MeetMember;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-
-import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @ToString(of = {"id", "chatType", "email", "message"})
-public class Chat {
+public class Chat extends BaseEntity {
 
     @Id
     @GeneratedValue
     private Long id;
-
-    @Column
-    @NotNull
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @Column
-    @NotNull
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
     @NotNull

--- a/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
@@ -1,13 +1,14 @@
 package com.nimble.server_spring.modules.chat;
 
+import com.nimble.server_spring.modules.meet.Meet;
+import com.nimble.server_spring.modules.meet.MeetMember;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -17,12 +18,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
-@ToString
-@EqualsAndHashCode(of = "id")
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@ToString(of = {"id", "chatType", "email", "message"})
 public class Chat {
 
     @Id
@@ -40,13 +38,37 @@ public class Chat {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private ChatType chatType;
 
-    private Long meetId;
-
+    @NotNull
     private String email;
 
-    private Long memberId;
-
     private String message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meet_id")
+    @NotNull
+    private Meet meet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @NotNull
+    private MeetMember meetMember;
+
+
+    @Builder
+    public Chat(
+        ChatType chatType,
+        String email,
+        String message,
+        Meet meet,
+        MeetMember meetMember
+    ) {
+        this.chatType = chatType;
+        this.email = email;
+        this.message = message;
+        this.meet = meet;
+        this.meetMember = meetMember;
+    }
 }

--- a/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(of = {"id", "chatType", "email", "message"})
+@ToString(of = {"id", "chatType", "message"})
 public class Chat extends BaseEntity {
 
     @Id
@@ -25,9 +25,6 @@ public class Chat extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @NotNull
     private ChatType chatType;
-
-    @NotNull
-    private String email;
 
     private String message;
 
@@ -45,13 +42,11 @@ public class Chat extends BaseEntity {
     @Builder
     public Chat(
         ChatType chatType,
-        String email,
         String message,
         Meet meet,
         MeetMember meetMember
     ) {
         this.chatType = chatType;
-        this.email = email;
         this.message = message;
         this.meet = meet;
         this.meetMember = meetMember;

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
@@ -70,8 +70,8 @@ public class ChatController {
         Chat chat = Chat.builder()
             .chatType(ChatType.ENTER)
             .email(user.getEmail())
-            .memberId(meetMember.getId())
-            .meetId(meetId)
+            .meet(meetMember.getMeet())
+            .meetMember(meetMember)
             .build();
         chatRepository.save(chat);
 
@@ -101,9 +101,9 @@ public class ChatController {
         Chat chat = Chat.builder()
             .chatType(ChatType.TALK)
             .email(user.getEmail())
-            .memberId(meetMember.getId())
-            .meetId(meetId)
             .message(chatTalkRequestDto.getMessage())
+            .meet(meetMember.getMeet())
+            .meetMember(meetMember)
             .build();
         chatRepository.save(chat);
 
@@ -134,7 +134,8 @@ public class ChatController {
         Chat chat = Chat.builder()
             .chatType(ChatType.LEAVE)
             .email(email)
-            .memberId(meetMember.getId())
+            .meet(meetMember.getMeet())
+            .meetMember(meetMember)
             .build();
         chatRepository.save(chat);
 

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
@@ -69,7 +69,6 @@ public class ChatController {
 
         Chat chat = Chat.builder()
             .chatType(ChatType.ENTER)
-            .email(user.getEmail())
             .meet(meetMember.getMeet())
             .meetMember(meetMember)
             .build();
@@ -100,7 +99,6 @@ public class ChatController {
 
         Chat chat = Chat.builder()
             .chatType(ChatType.TALK)
-            .email(user.getEmail())
             .message(chatTalkRequestDto.getMessage())
             .meet(meetMember.getMeet())
             .meetMember(meetMember)
@@ -133,7 +131,6 @@ public class ChatController {
 
         Chat chat = Chat.builder()
             .chatType(ChatType.LEAVE)
-            .email(email)
             .meet(meetMember.getMeet())
             .meetMember(meetMember)
             .build();

--- a/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
@@ -24,7 +24,7 @@ public class ChatResponseDto {
         return ChatResponseDto.builder()
             .createdAt(chat.getCreatedAt())
             .chatType(chat.getChatType())
-            .email(chat.getEmail())
+            .email(chat.getMeetMember().getUser().getEmail())
             .memberId(chat.getMeetMember().getId())
             .message(chat.getMessage())
             .build();

--- a/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
@@ -25,7 +25,7 @@ public class ChatResponseDto {
             .createdAt(chat.getCreatedAt())
             .chatType(chat.getChatType())
             .email(chat.getEmail())
-            .memberId(chat.getMemberId())
+            .memberId(chat.getMeetMember().getId())
             .message(chat.getMessage())
             .build();
     }

--- a/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
@@ -1,5 +1,6 @@
 package com.nimble.server_spring.modules.meet;
 
+import com.nimble.server_spring.infra.persistence.BaseEntity;
 import com.nimble.server_spring.modules.user.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -8,34 +9,19 @@ import java.util.Optional;
 
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @ToString(of = {"id", "meetName", "description"})
-public class Meet {
+public class Meet extends BaseEntity {
 
     @Id
     @GeneratedValue
     private Long id;
-
-    @Column
-    @NotNull
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @Column
-    @NotNull
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     @Column
     @NotNull

--- a/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
@@ -18,12 +18,9 @@ import java.util.List;
 
 @Entity
 @Getter
-@ToString
-@EqualsAndHashCode(of = "id")
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@ToString(of = {"id", "meetName", "description"})
 public class Meet {
 
     @Id
@@ -50,13 +47,20 @@ public class Meet {
     private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @NotNull
     @JoinColumn(name = "host_id")
+    @NotNull
     private User host;
 
     @OneToMany(mappedBy = "meet", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
+    @NotNull
     private List<MeetMember> meetMembers = new ArrayList<>();
+
+    @Builder
+    public Meet(String meetName, String description, User host) {
+        this.meetName = meetName;
+        this.description = description;
+        this.host = host;
+    }
 
     public boolean isHost(Long userId) {
         return this.host.getId().equals(userId);

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetMember.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetMember.java
@@ -14,11 +14,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
-@EqualsAndHashCode(of = "id")
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@ToString(of = {"id", "memberRole", "isEntered"})
 public class MeetMember {
 
     @Id
@@ -34,28 +32,28 @@ public class MeetMember {
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @NotNull
     @JoinColumn(name = "meet_id")
+    @NotNull
     private Meet meet;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @NotNull
     @JoinColumn(name = "user_id")
+    @NotNull
     private User user;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private MemberRole memberRole;
 
     @Convert(converter = BooleanToYNConverter.class)
-    private boolean isEntered;
+    @NotNull
+    private boolean isEntered = false;
 
-    @Override
-    public String toString() {
-        return "MeetMember{" +
-               "id=" + id +
-               ", createdAt=" + createdAt +
-               ", updatedAt=" + updatedAt +
-               '}';
+    @Builder
+    public MeetMember(Meet meet, User user, MemberRole memberRole) {
+        this.meet = meet;
+        this.user = user;
+        this.memberRole = memberRole;
     }
 
     public void enterMeet() {

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
@@ -27,14 +27,12 @@ public class MeetService {
             .meetName(meetCreateRequestDto.getMeetName())
             .description(meetCreateRequestDto.getDescription())
             .host(user)
-            .meetMembers(new ArrayList<>())
             .build();
 
         MeetMember meetMember = MeetMember.builder()
             .meet(meet)
             .user(user)
             .memberRole(MemberRole.HOST)
-            .isEntered(false)
             .build();
         meet.addMeetMember(meetMember);
 
@@ -69,7 +67,6 @@ public class MeetService {
         MeetMember meetMember = MeetMember.builder()
             .meet(meet)
             .user(userToInvite)
-            .isEntered(false)
             .memberRole(MemberRole.MEMBER)
             .build();
         meet.addMeetMember(meetMember);

--- a/src/main/java/com/nimble/server_spring/modules/user/User.java
+++ b/src/main/java/com/nimble/server_spring/modules/user/User.java
@@ -3,6 +3,7 @@ package com.nimble.server_spring.modules.user;
 import com.nimble.server_spring.modules.auth.enums.OauthProvider;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -13,41 +14,52 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@ToString
-@EqualsAndHashCode(of = "id")
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@ToString(of = {"id", "email", "nickname"})
 public class User {
 
-  @Id
-  @GeneratedValue
-  private Long id;
+    @Id
+    @GeneratedValue
+    private Long id;
 
-  @Column(nullable = false)
-  @CreatedDate
-  private LocalDateTime createdAt;
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createdAt;
 
-  @Column(nullable = false)
-  @LastModifiedDate
-  private LocalDateTime updatedAt;
+    @NotNull
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
-  @Column(unique = true, nullable = false)
-  @Email
-  private String email;
+    @Column(unique = true)
+    @NotNull
+    @Email
+    private String email;
 
-  @Pattern(regexp = "^\\$2[ayb]\\$.{56}$", message = "비밀번호는 BCrpyt로 암호화된 문자열이어야 합니다.")
-  private String password;
+    @Pattern(regexp = "^\\$2[ayb]\\$.{56}$", message = "비밀번호는 BCrpyt로 암호화된 문자열이어야 합니다.")
+    private String password;
 
-  @Column()
-  private String nickname;
+    @NotNull
+    private String nickname;
 
-  @Column
-  @Enumerated(EnumType.STRING)
-  @Builder.Default
-  private OauthProvider providerType = OauthProvider.LOCAL;
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private OauthProvider providerType;
 
-  @Column(nullable = true)
-  private String providerId;
+    private String providerId;
+
+    @Builder
+    public User(
+        String email,
+        String password,
+        String nickname,
+        OauthProvider providerType,
+        String providerId
+    ) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.providerType = providerType;
+        this.providerId = providerId;
+    }
 }

--- a/src/main/java/com/nimble/server_spring/modules/user/User.java
+++ b/src/main/java/com/nimble/server_spring/modules/user/User.java
@@ -1,35 +1,22 @@
 package com.nimble.server_spring.modules.user;
 
+import com.nimble.server_spring.infra.persistence.BaseEntity;
 import com.nimble.server_spring.modules.auth.enums.OauthProvider;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @ToString(of = {"id", "email", "nickname"})
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue
     private Long id;
-
-    @NotNull
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @NotNull
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     @Column(unique = true)
     @NotNull


### PR DESCRIPTION
### 태스크 목록
- [x] jpa entity 정의 부분 개선
    - [x] @NoArgsConstructor의 접근 제어를 PROTECTED로 변경
    - [x] @AllArgsConstructor 제거, @Builder를 직접 정의한 생성자에 적용하도록 변경
    - [x] @ToString에서 of를 사용하여 필드를 지정하도록 변경, 연관관계 필드 제외
    - [x] nullable=false 대신 @NotNull 사용
- [x] Chat 엔티티 개선
    - [x] 외래키를 직접 사용하지 않고, 연관 객체의 참조를 사용하도록 변경
    - [x] email 프로퍼티를 제거하여 데이터의 정합성 개선
- [x] MappedSuperclass를 이용하여 생성시간, 수정시간 정보를 추상 클래스에 정의하여 상속

### 관련 참고 자료
- [nullable=false와 @NotNull 비교](https://kafcamus.tistory.com/15)  
- [올바른 JPA Entity, @Builder 사용법](https://velog.io/@mooh2jj/%EC%98%AC%EB%B0%94%EB%A5%B8-%EC%97%94%ED%8B%B0%ED%8B%B0-Builder-%EC%82%AC%EC%9A%A9%EB%B2%95)
