### PR TITLE
채팅 관련 기능 강화 및 쿼리 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     // spring security messaging
     implementation 'org.springframework.security:spring-security-messaging'
 
+    // spring data jpa logging
+    developmentOnly 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
     // querydsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"

--- a/src/main/java/com/nimble/server_spring/infra/error/ErrorCode.java
+++ b/src/main/java/com/nimble/server_spring/infra/error/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     // 404 NOT_FOUND
     MEET_NOT_FOUND(MEET, NOT_FOUND, "미팅을 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(MEET, NOT_FOUND, "미팅 멤버를 찾을 수 없습니다."),
+    NOT_MEET_MEMBER(MEET, NOT_FOUND, "미팅 멤버가 아닙니다."),
 
     // 409 CONFLICT
     MEET_INVITE_LIMIT_OVER(MEET, CONFLICT, "초대 가능한 인원을 초과했습니다."),

--- a/src/main/java/com/nimble/server_spring/infra/http/BearerTokenParser.java
+++ b/src/main/java/com/nimble/server_spring/infra/http/BearerTokenParser.java
@@ -1,6 +1,7 @@
 package com.nimble.server_spring.infra.http;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import org.springframework.util.StringUtils;
 
 public class BearerTokenParser {
@@ -18,12 +19,11 @@ public class BearerTokenParser {
         return new BearerTokenParser(request);
     }
 
-    public String getToken() {
+    public Optional<String> getToken() {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(BEARER_PREFIX)) {
-            return null;
+            return Optional.empty();
         }
-        return bearerToken.substring(BEARER_PREFIX.length());
-
+        return Optional.of(bearerToken.substring(BEARER_PREFIX.length()));
     }
 }

--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManager.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManager.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public interface AuthTokenManager {
 
-    AuthToken publishToken(String email, @Nullable String role, JwtTokenType tokenType);
+    AuthToken publishToken(Long userId, @Nullable String role, JwtTokenType tokenType);
 
     Optional<Claims> getTokenClaims(String tokenValue, JwtTokenType tokenType);
 

--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManager.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManager.java
@@ -1,5 +1,6 @@
 package com.nimble.server_spring.infra.jwt;
 
+import com.nimble.server_spring.infra.security.RoleType;
 import io.jsonwebtoken.Claims;
 import jakarta.annotation.Nullable;
 import java.util.Collection;
@@ -8,7 +9,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public interface AuthTokenManager {
 
-    AuthToken publishToken(Long userId, @Nullable String role, JwtTokenType tokenType);
+    AuthToken publishToken(Long userId, @Nullable RoleType role, JwtTokenType tokenType);
 
     Optional<Claims> getTokenClaims(String tokenValue, JwtTokenType tokenType);
 

--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManager.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManager.java
@@ -13,5 +13,7 @@ public interface AuthTokenManager {
 
     Optional<Claims> getTokenClaims(String tokenValue, JwtTokenType tokenType);
 
+    boolean validateToken(String tokenValue, JwtTokenType tokenType);
+
     Collection<? extends SimpleGrantedAuthority> getAuthorities(Claims claims);
 }

--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManagerImpl.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManagerImpl.java
@@ -34,10 +34,10 @@ public class AuthTokenManagerImpl implements AuthTokenManager {
         this.refreshTokenExpiry = refreshTokenExpiry * 1000;
     }
 
-    public AuthToken publishToken(String email, @Nullable String role, JwtTokenType tokenType) {
+    public AuthToken publishToken(Long userId, @Nullable String role, JwtTokenType tokenType) {
         Date tokenExpiry = getTokenExpiryOf(tokenType);
         Key tokenKey = getKeyOf(tokenType);
-        String tokenValue = buildTokenValue(email, tokenExpiry, tokenKey, role);
+        String tokenValue = buildTokenValue(userId.toString(), tokenExpiry, tokenKey, role);
         return new AuthToken(tokenValue, tokenExpiry);
     }
 

--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManagerImpl.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManagerImpl.java
@@ -1,5 +1,6 @@
 package com.nimble.server_spring.infra.jwt;
 
+import com.nimble.server_spring.infra.security.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.Nullable;
@@ -34,9 +35,15 @@ public class AuthTokenManagerImpl implements AuthTokenManager {
         this.refreshTokenExpiry = refreshTokenExpiry * 1000;
     }
 
-    public AuthToken publishToken(Long userId, @Nullable String role, JwtTokenType tokenType) {
+    public AuthToken publishToken(
+        Long userId, @Nullable RoleType roleType, JwtTokenType tokenType
+    ) {
         Date tokenExpiry = getTokenExpiryOf(tokenType);
         Key tokenKey = getKeyOf(tokenType);
+        String role = Optional.ofNullable(roleType)
+            .map(RoleType::getCode)
+            .orElse(null);
+
         String tokenValue = buildTokenValue(userId.toString(), tokenExpiry, tokenKey, role);
         return new AuthToken(tokenValue, tokenExpiry);
     }

--- a/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManagerImpl.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/AuthTokenManagerImpl.java
@@ -74,25 +74,21 @@ public class AuthTokenManagerImpl implements AuthTokenManager {
 
     public Optional<Claims> getTokenClaims(String tokenValue, JwtTokenType tokenType) {
         Key tokenKey = getKeyOf(tokenType);
-        Claims claims = null;
         try {
-            claims = Jwts.parserBuilder()
+            Claims claims = Jwts.parserBuilder()
                 .setSigningKey(tokenKey)
                 .build()
                 .parseClaimsJws(tokenValue)
                 .getBody();
-        } catch (SecurityException e) {
-            log.info("Invalid JWT Signature.");
-        } catch (MalformedJwtException e) {
-            log.info("Invalid JWT Token.");
-        } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token.");
-        } catch (UnsupportedJwtException e) {
-            log.info("Unsupported Jwt Token.");
-        } catch (IllegalArgumentException e) {
-            log.info("JWT token compact of handler are invalid.");
+            return Optional.of(claims);
+        } catch (Exception e) {
+            return Optional.empty();
         }
-        return Optional.ofNullable(claims);
+    }
+
+    @Override
+    public boolean validateToken(String tokenValue, JwtTokenType tokenType) {
+        return getTokenClaims(tokenValue, tokenType).isPresent();
     }
 
     public Collection<? extends SimpleGrantedAuthority> getAuthorities(Claims claims) {

--- a/src/main/java/com/nimble/server_spring/infra/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nimble/server_spring/infra/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -31,10 +32,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         @NonNull HttpServletResponse response,
         @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        String tokenValue = BearerTokenParser.from(request).getToken();
-
         Authentication authentication;
         try {
+            String tokenValue = BearerTokenParser.from(request).getToken()
+                .orElseThrow(() -> new BadCredentialsException("토큰이 존재하지 않습니다."));
             authentication = jwtAuthenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(tokenValue, null)
             );

--- a/src/main/java/com/nimble/server_spring/infra/security/LocalLoginAuthenticationManager.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/LocalLoginAuthenticationManager.java
@@ -7,15 +7,13 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @RequiredArgsConstructor
 @Slf4j
 public class LocalLoginAuthenticationManager implements AuthenticationManager {
 
-    private final UserDetailsService userDetailsService;
+    private final CustomUserDetailsService userDetailsService;
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -25,13 +23,14 @@ public class LocalLoginAuthenticationManager implements AuthenticationManager {
         String email = String.valueOf(authentication.getPrincipal());
         String password = String.valueOf(authentication.getCredentials());
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        CustomUserDetails userDetails =
+            (CustomUserDetails) userDetailsService.loadUserByUsername(email);
         if (!passwordEncoder.matches(password, userDetails.getPassword())) {
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
         return new UsernamePasswordAuthenticationToken(
-            userDetails.getUsername(),
+            userDetails.getUserId(),
             userDetails.getPassword(),
             userDetails.getAuthorities()
         );

--- a/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
@@ -41,12 +41,12 @@ public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
         String role = userDetails.getRoleType().getCode();
 
         AuthToken accessToken = authTokenManager.publishToken(
-            email,
+            userDetails.getUser().getId(),
             role,
             JwtTokenType.ACCESS
         );
         AuthToken refreshToken = authTokenManager.publishToken(
-            email,
+            userDetails.getUser().getId(),
             null,
             JwtTokenType.REFRESH
         );

--- a/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
@@ -45,7 +45,7 @@ public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
 
         AuthToken accessToken = authTokenManager.publishToken(
             userId,
-            roleType.getCode(),
+            roleType,
             JwtTokenType.ACCESS
         );
         AuthToken refreshToken = authTokenManager.publishToken(

--- a/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
+++ b/src/main/java/com/nimble/server_spring/infra/security/LocalLoginSuccessHandler.java
@@ -9,6 +9,8 @@ import com.nimble.server_spring.modules.auth.JwtToken;
 import com.nimble.server_spring.modules.auth.JwtTokenRepository;
 import com.nimble.server_spring.modules.auth.TokenCookieFactory;
 import com.nimble.server_spring.modules.auth.dto.response.LoginResponseDto;
+import com.nimble.server_spring.modules.user.User;
+import com.nimble.server_spring.modules.user.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -25,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final AuthTokenManager authTokenManager;
-    private final CustomUserDetailsService userDetailsService;
+    private final UserRepository userRepository;
     private final JwtTokenRepository jwtTokenRepository;
     private final ObjectMapper objectMapper;
     private final TokenCookieFactory tokenCookieFactory;
@@ -35,26 +37,30 @@ public class LocalLoginSuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(
         HttpServletRequest request, HttpServletResponse response, Authentication authentication
     ) throws IOException {
-        String email = String.valueOf(authentication.getPrincipal());
-        CustomUserDetails userDetails =
-            (CustomUserDetails) userDetailsService.loadUserByUsername(email);
-        String role = userDetails.getRoleType().getCode();
+        Long userId = (Long) authentication.getPrincipal();
+        RoleType roleType = authentication.getAuthorities().stream()
+            .findFirst()
+            .map(authority -> RoleType.of(authority.getAuthority()))
+            .orElseGet(() -> RoleType.GUEST);
 
         AuthToken accessToken = authTokenManager.publishToken(
-            userDetails.getUser().getId(),
-            role,
+            userId,
+            roleType.getCode(),
             JwtTokenType.ACCESS
         );
         AuthToken refreshToken = authTokenManager.publishToken(
-            userDetails.getUser().getId(),
+            userId,
             null,
             JwtTokenType.REFRESH
         );
 
-        JwtToken jwtToken = jwtTokenRepository.findOneByUserId(userDetails.getUserId())
+        JwtToken jwtToken = jwtTokenRepository.findOneByUserId(userId)
             .map(token -> token.reissue(accessToken, refreshToken))
-            .orElseGet(() -> JwtToken.issue(accessToken, refreshToken, userDetails.getUser()));
-        jwtTokenRepository.save(jwtToken);
+            .orElseGet(() -> {
+                User user = userRepository.getReferenceById(userId);
+                JwtToken newToken = JwtToken.issue(accessToken, refreshToken, user);
+                return jwtTokenRepository.save(newToken);
+            });
 
         response.addCookie(
             tokenCookieFactory.createAccessTokenCookie(jwtToken.getAccessToken())

--- a/src/main/java/com/nimble/server_spring/modules/auth/AuthController.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/AuthController.java
@@ -81,10 +81,8 @@ public class AuthController {
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.REFRESH_TOKEN_DOES_NOT_EXIST));
         String refreshToken = refreshTokenCookie.getValue();
 
-        String accessToken = BearerTokenParser.from(request).getToken();
-        if (accessToken == null) {
-            throw new ErrorCodeException(ErrorCode.ACCESS_TOKEN_DOES_NOT_EXIST);
-        }
+        String accessToken = BearerTokenParser.from(request).getToken()
+            .orElseThrow(() -> new ErrorCodeException(ErrorCode.ACCESS_TOKEN_DOES_NOT_EXIST));
 
         JwtToken jwtToken = authService.rotateRefreshToken(refreshToken, accessToken);
 

--- a/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
@@ -64,7 +64,7 @@ public class AuthService {
 
         AuthToken newAccessToken = authTokenManager.publishToken(
             jwtToken.getUser().getId(),
-            RoleType.USER.getCode(),
+            RoleType.USER,
             JwtTokenType.ACCESS
         );
         AuthToken newRefreshToken = authTokenManager.publishToken(

--- a/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
@@ -27,7 +27,6 @@ public class AuthService {
     private final AuthTokenManager authTokenManager;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
     public User signup(LocalSignupRequestDto localSignupDto) {
         boolean isEmailAlreadyExists = userRepository.existsByEmail(
             localSignupDto.getEmail()
@@ -56,8 +55,7 @@ public class AuthService {
             throw new ErrorCodeException(ErrorCode.INCONSISTENT_ACCESS_TOKEN);
         }
         boolean isRefreshTokenValid = authTokenManager
-            .getTokenClaims(prevRefreshToken, JwtTokenType.REFRESH)
-            .isPresent();
+            .validateToken(prevRefreshToken, JwtTokenType.REFRESH);
         if (!isRefreshTokenValid) {
             throw new ErrorCodeException(ErrorCode.EXPIRED_REFRESH_TOKEN);
         }

--- a/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/AuthService.java
@@ -63,12 +63,12 @@ public class AuthService {
         }
 
         AuthToken newAccessToken = authTokenManager.publishToken(
-            jwtToken.getUser().getEmail(),
+            jwtToken.getUser().getId(),
             RoleType.USER.getCode(),
             JwtTokenType.ACCESS
         );
         AuthToken newRefreshToken = authTokenManager.publishToken(
-            jwtToken.getUser().getEmail(),
+            jwtToken.getUser().getId(),
             null,
             JwtTokenType.REFRESH
         );

--- a/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
+++ b/src/main/java/com/nimble/server_spring/modules/auth/JwtToken.java
@@ -33,7 +33,7 @@ public class JwtToken extends BaseEntity {
     @NotNull
     private LocalDateTime expiresAt;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     @NotNull
     private User user;

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatRepository.java
@@ -1,6 +1,21 @@
 package com.nimble.server_spring.modules.chat;
 
+import com.nimble.server_spring.modules.chat.dto.response.ChatResponseDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+    @Query("select new com.nimble.server_spring.modules.chat.dto.response.ChatResponseDto"
+           + "(c.id, mm.id, u.email, c.createdAt, c.chatType, c.message) from Chat c "
+           + "join c.meetMember mm "
+           + "join mm.user u "
+           + "where c.meet.id = :meetId")
+    Slice<ChatResponseDto> findAllByMeetId(
+        @Param("meetId") Long meetId,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
@@ -9,16 +9,32 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class ChatResponseDto {
 
+    private Long chatId;
+    private Long memberId;
+    private String email;
     private LocalDateTime createdAt;
     private ChatType chatType;
-    private String email;
-    private Long memberId;
     private String message;
+
+    @Builder
+    public ChatResponseDto(
+        Long chatId,
+        Long memberId,
+        String email,
+        LocalDateTime createdAt,
+        ChatType chatType,
+        String message
+    ) {
+        this.chatId = chatId;
+        this.memberId = memberId;
+        this.email = email;
+        this.createdAt = createdAt;
+        this.chatType = chatType;
+        this.message = message;
+    }
 
     public static ChatResponseDto fromChat(Chat chat) {
         return ChatResponseDto.builder()

--- a/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
@@ -48,8 +48,8 @@ public class Meet extends BaseEntity {
         this.host = host;
     }
 
-    public boolean isHost(Long userId) {
-        return this.host.getId().equals(userId);
+    public boolean isHost(User user) {
+        return this.host.getId().equals(user.getId());
     }
 
     public Optional<MeetMember> findMember(Long memberId) {

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetController.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetController.java
@@ -46,7 +46,7 @@ public class MeetController {
     @GetMapping
     @Operation(summary = "미팅 목록 조회", description = "내가 생성했거나 초대 받은 미팅을 조회합니다.")
     public ResponseEntity<List<MeetResponseDto>> getMeets(Principal principal) {
-        User currentUser = userService.getUserByPrincipal(principal);
+        User currentUser = userService.getUserByPrincipalLazy(principal);
 
         List<Meet> meetList = meetRepository.findHostedOrInvitedMeetsByUserId(currentUser.getId());
         List<MeetResponseDto> meetResponseDtoList = meetList.stream()
@@ -84,7 +84,7 @@ public class MeetController {
         Long meetId,
         Principal principal
     ) {
-        User currentUser = userService.getUserByPrincipal(principal);
+        User currentUser = userService.getUserByPrincipalLazy(principal);
 
         Meet meet = meetRepository.findMeetByIdIfHostedOrInvited(meetId, currentUser.getId())
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
@@ -107,7 +107,7 @@ public class MeetController {
         MeetInviteRequestDto meetInviteRequestDto,
         Principal principal
     ) {
-        User currentUser = userService.getUserByPrincipal(principal);
+        User currentUser = userService.getUserByPrincipalLazy(principal);
 
         MeetMember meetMember = meetService.invite(
             currentUser,
@@ -133,7 +133,7 @@ public class MeetController {
         Long memberId,
         Principal principal
     ) {
-        User currentUser = userService.getUserByPrincipal(principal);
+        User currentUser = userService.getUserByPrincipalLazy(principal);
 
         MeetMember meetMember = meetService.kickOut(
             currentUser,
@@ -161,7 +161,7 @@ public class MeetController {
         Integer size,
         Principal principal
     ) {
-        User currentUser = userService.getUserByPrincipal(principal);
+        User currentUser = userService.getUserByPrincipalLazy(principal);
         if (!meetMemberRepository.existsByUser_IdAndMeet_Id(
             currentUser.getId(),
             meetId

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetMemberRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetMemberRepository.java
@@ -8,4 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 public interface MeetMemberRepository extends JpaRepository<MeetMember, Long> {
 
     Optional<MeetMember> findByUserIdAndMeetId(Long userId, Long meetId);
+
+    boolean existsByUser_IdAndMeet_Id(Long userId, Long meetId);
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepository.java
@@ -1,9 +1,13 @@
 package com.nimble.server_spring.modules.meet;
 
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public interface MeetRepository extends JpaRepository<Meet, Long>, MeetRepositoryExtension {
 
+    @EntityGraph(attributePaths = {"host", "meetMembers", "meetMembers.user"})
+    Optional<Meet> findDistinctByIdAndHost_Id(Long id, Long hostId);
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtensionImpl.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtensionImpl.java
@@ -22,10 +22,13 @@ public class MeetRepositoryExtensionImpl implements MeetRepositoryExtension {
         QMeetMember meetMember = QMeetMember.meetMember;
         QUser member = new QUser("member");
 
-        List<Meet> meetList = jpaQueryFactory.selectFrom(meet)
+        return jpaQueryFactory.selectFrom(meet)
             .leftJoin(meet.host, host)
+            .fetchJoin()
             .leftJoin(meet.meetMembers, meetMember)
+            .fetchJoin()
             .leftJoin(meetMember.user, member)
+            .fetchJoin()
 
             .where(meet.id.in(
                     JPAExpressions
@@ -38,7 +41,6 @@ public class MeetRepositoryExtensionImpl implements MeetRepositoryExtension {
                 )
             )
             .fetch();
-        return meetList;
     }
 
     @Override
@@ -50,8 +52,11 @@ public class MeetRepositoryExtensionImpl implements MeetRepositoryExtension {
 
         Meet fetchedMeet = jpaQueryFactory.selectFrom(meet)
             .leftJoin(meet.host, host)
+            .fetchJoin()
             .leftJoin(meet.meetMembers, meetMember)
+            .fetchJoin()
             .leftJoin(meetMember.user, member)
+            .fetchJoin()
             .where(meet.id.eq(meetId)
                 .and(host.id.eq(userId)
                     .or(member.id.eq(userId))

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
@@ -40,13 +40,14 @@ public class MeetService {
     }
 
     public MeetMember invite(
-        User currentUser, Long meetId,
+        User currentUser,
+        Long meetId,
         MeetInviteRequestDto meetInviteRequestDto
     ) {
         Meet meet = meetRepository.findById(meetId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
 
-        if (!meet.isHost(currentUser.getId())) {
+        if (!meet.isHost(currentUser)) {
             throw new ErrorCodeException(ErrorCode.MEET_NOT_FOUND);
         }
 
@@ -78,7 +79,7 @@ public class MeetService {
         Meet meet = meetRepository.findById(meetId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
 
-        if (!meet.isHost(currentUser.getId())) {
+        if (!meet.isHost(currentUser)) {
             throw new ErrorCodeException(ErrorCode.MEET_NOT_FOUND);
         }
 

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
@@ -44,12 +44,8 @@ public class MeetService {
         Long meetId,
         MeetInviteRequestDto meetInviteRequestDto
     ) {
-        Meet meet = meetRepository.findById(meetId)
+        Meet meet = meetRepository.findDistinctByIdAndHost_Id(meetId, currentUser.getId())
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
-
-        if (!meet.isHost(currentUser)) {
-            throw new ErrorCodeException(ErrorCode.MEET_NOT_FOUND);
-        }
 
         if (meet.getMeetMembers().size() >= INVITE_LIMIT_NUMBER) {
             throw new ErrorCodeException(ErrorCode.MEET_INVITE_LIMIT_OVER);
@@ -76,12 +72,8 @@ public class MeetService {
     }
 
     public MeetMember kickOut(User currentUser, Long meetId, Long memberId) {
-        Meet meet = meetRepository.findById(meetId)
+        Meet meet = meetRepository.findDistinctByIdAndHost_Id(meetId, currentUser.getId())
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
-
-        if (!meet.isHost(currentUser)) {
-            throw new ErrorCodeException(ErrorCode.MEET_NOT_FOUND);
-        }
 
         MeetMember meetMember = meet.findMember(memberId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/nimble/server_spring/modules/user/UserService.java
+++ b/src/main/java/com/nimble/server_spring/modules/user/UserService.java
@@ -20,7 +20,14 @@ public class UserService {
     }
 
     public User getUserByPrincipal(Principal principal) {
-        String email = principal.getName();
-        return getUserByEmail(email);
+        Long userId = Long.parseLong(principal.getName());
+        return userRepository.findById(userId).orElseThrow(
+            () -> new ErrorCodeException(ErrorCode.USER_NOT_FOUND)
+        );
+    }
+
+    public User getUserByPrincipalLazy(Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        return userRepository.getReferenceById(userId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,9 +10,11 @@ spring:
       minimum-idle: 10
       maximum-pool-size: 20
   jpa:
-    #    show_sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
   jackson:
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
@@ -25,6 +27,7 @@ jwt:
 logging:
   level:
     org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+    org.hibernate.sql: debug
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
- [x] 채팅 목록 조회 API 개발
    - [x] 페이징 처리 적용, 정렬은 생성일 내림차순으로 기본 적용
    - [x] 조회시 dto를 사용하여 성능 최적화
- [x] Meet 데이터 조회 로직에 fetch join을 적용하여 쿼리 최적화
    - [x] QueryDsl 사용 부분에 fetchJoin() 적용
    - [x] Spring Data JPA 사용 부분에 @EntityGraph 적용
- [x] JWT Token에서 subject에 email이 아닌 userId를 넣도록 수정
    - 대부분의 비즈니스 로직에서 User의 id를 기반으로 로직을 구성하므로, userId가 저장되면 User 조회 횟수를 줄여서 최적화 가능
    - [x] principal 정보를 이용해서 proxy로 User 조회하는 메서드 추가
- [x] 로그인 로직의 쿼리 최적화
    - [x] LocalLoginAuthenticationManager에서 userId를 principal로 전달하도록 변경
    - [x] LocalLoginSuccessHandler에서는 authentication에 담긴 정보를 사용하여, User 조회 없이 토큰을 발급하도록 수정
    - [x] JwtToken과 User 사이에 Lazy Loading 적용
- [x] AuthTokenManager에서 토큰 발급 시 RoleType으로 권한을 받도록 수정
- [x] 인증 관련 로직 일부 리팩토링
    - [x] Optional 적용, 추상화 개선

### 참고자료 목록
김영한님의 스프링 데이터 JPA 강의