### PR TITLE
Meet - User 간 테이블 및 엔티티 관계 개선, 채팅 관련 버그 수정 

### DIFF
--- a/src/main/java/com/nimble/server_spring/infra/error/ErrorCode.java
+++ b/src/main/java/com/nimble/server_spring/infra/error/ErrorCode.java
@@ -1,7 +1,6 @@
 package com.nimble.server_spring.infra.error;
 
 import static com.nimble.server_spring.infra.error.DomainType.AUTH;
-import static com.nimble.server_spring.infra.error.DomainType.CHAT;
 import static com.nimble.server_spring.infra.error.DomainType.GLOBAL;
 import static com.nimble.server_spring.infra.error.DomainType.MEET;
 import static com.nimble.server_spring.infra.error.DomainType.USER;
@@ -46,8 +45,8 @@ public enum ErrorCode {
 
     // 404 NOT_FOUND
     MEET_NOT_FOUND(MEET, NOT_FOUND, "미팅을 찾을 수 없습니다."),
-    MEMBER_NOT_FOUND(MEET, NOT_FOUND, "미팅 멤버를 찾을 수 없습니다."),
-    NOT_MEET_MEMBER(MEET, NOT_FOUND, "미팅 멤버가 아닙니다."),
+    MEET_USER_NOT_FOUND(MEET, NOT_FOUND, "미팅 멤버를 찾을 수 없습니다."),
+    NOT_MEET_USER(MEET, NOT_FOUND, "미팅 멤버가 아닙니다."),
 
     // 409 CONFLICT
     MEET_INVITE_LIMIT_OVER(MEET, CONFLICT, "초대 가능한 인원을 초과했습니다."),
@@ -62,13 +61,6 @@ public enum ErrorCode {
 
     // 404 NOT_FOUND
     USER_NOT_FOUND_BY_EMAIL(USER, NOT_FOUND, "이메일에 해당하는 사용자가 존재하지 않습니다."),
-
-    // ==============================================================
-    // CHAT ERROR CODE
-    // ==============================================================
-
-    // 404 NOT_FOUND
-    MEET_MEMBER_NOT_FOUND(CHAT, NOT_FOUND, "미팅 멤버를 찾을 수 없습니다."),
 
     // ==============================================================
     // GLOBAL

--- a/src/main/java/com/nimble/server_spring/infra/error/ErrorCode.java
+++ b/src/main/java/com/nimble/server_spring/infra/error/ErrorCode.java
@@ -6,6 +6,7 @@ import static com.nimble.server_spring.infra.error.DomainType.MEET;
 import static com.nimble.server_spring.infra.error.DomainType.USER;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -45,8 +46,9 @@ public enum ErrorCode {
 
     // 404 NOT_FOUND
     MEET_NOT_FOUND(MEET, NOT_FOUND, "미팅을 찾을 수 없습니다."),
-    MEET_USER_NOT_FOUND(MEET, NOT_FOUND, "미팅 멤버를 찾을 수 없습니다."),
-    NOT_MEET_USER(MEET, NOT_FOUND, "미팅 멤버가 아닙니다."),
+    MEET_USER_NOT_FOUND(MEET, NOT_FOUND, "미팅 참여자를 찾을 수 없습니다."),
+    NOT_MEET_USER_FORBIDDEN(MEET, FORBIDDEN, "미팅 참여자가 아니므로 요청이 불가능합니다."),
+    NOT_MEET_HOST_FORBIDDEN(MEET, FORBIDDEN, "미팅 호스트가 아니므로 요청이 불가능합니다."),
 
     // 409 CONFLICT
     MEET_INVITE_LIMIT_OVER(MEET, CONFLICT, "초대 가능한 인원을 초과했습니다."),

--- a/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/Chat.java
@@ -2,7 +2,7 @@ package com.nimble.server_spring.modules.chat;
 
 import com.nimble.server_spring.infra.persistence.BaseEntity;
 import com.nimble.server_spring.modules.meet.Meet;
-import com.nimble.server_spring.modules.meet.MeetMember;
+import com.nimble.server_spring.modules.meet.MeetUser;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 
@@ -34,9 +34,9 @@ public class Chat extends BaseEntity {
     private Meet meet;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "meet_user_id")
     @NotNull
-    private MeetMember meetMember;
+    private MeetUser meetUser;
 
 
     @Builder
@@ -44,11 +44,11 @@ public class Chat extends BaseEntity {
         ChatType chatType,
         String message,
         Meet meet,
-        MeetMember meetMember
+        MeetUser meetUser
     ) {
         this.chatType = chatType;
         this.message = message;
         this.meet = meet;
-        this.meetMember = meetMember;
+        this.meetUser = meetUser;
     }
 }

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatController.java
@@ -14,6 +14,7 @@ import com.nimble.server_spring.modules.meet.MeetUser;
 import com.nimble.server_spring.modules.meet.MeetUserRepository;
 import com.nimble.server_spring.modules.user.User;
 import com.nimble.server_spring.modules.user.UserRepository;
+import com.nimble.server_spring.modules.user.UserService;
 import java.security.Principal;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,6 +49,7 @@ public class ChatController {
     private final ChatRepository chatRepository;
     private final MeetUserRepository meetUserRepository;
     private final UserRepository userRepository;
+    private final UserService userService;
     private final ObjectMapper objectMapper;
 
     @MessageMapping("/meet/{meetId}/chat/enter")
@@ -56,8 +58,7 @@ public class ChatController {
         SimpMessageHeaderAccessor headerAccessor
     ) {
         User user = Optional.ofNullable(headerAccessor.getUser())
-            .map(Principal::getName)
-            .flatMap(userRepository::findOneByEmail)
+            .map(userService::getUserByPrincipalLazy)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.UNAUTHENTICATED_REQUEST));
 
         MeetUser meetUser = meetUserRepository
@@ -88,8 +89,7 @@ public class ChatController {
         SimpMessageHeaderAccessor headerAccessor
     ) {
         User user = Optional.ofNullable(headerAccessor.getUser())
-            .map(Principal::getName)
-            .flatMap(userRepository::findOneByEmail)
+            .map(userService::getUserByPrincipalLazy)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.UNAUTHENTICATED_REQUEST));
 
         MeetUser meetUser = meetUserRepository

--- a/src/main/java/com/nimble/server_spring/modules/chat/ChatRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/ChatRepository.java
@@ -10,9 +10,9 @@ import org.springframework.data.repository.query.Param;
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     @Query("select new com.nimble.server_spring.modules.chat.dto.response.ChatResponseDto"
-           + "(c.id, mm.id, u.email, c.createdAt, c.chatType, c.message) from Chat c "
-           + "join c.meetMember mm "
-           + "join mm.user u "
+           + "(c.id, mu.id, u.email, c.createdAt, c.chatType, c.message) from Chat c "
+           + "join c.meetUser mu "
+           + "join mu.user u "
            + "where c.meet.id = :meetId")
     Slice<ChatResponseDto> findAllByMeetId(
         @Param("meetId") Long meetId,

--- a/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/chat/dto/response/ChatResponseDto.java
@@ -3,7 +3,6 @@ package com.nimble.server_spring.modules.chat.dto.response;
 import com.nimble.server_spring.modules.chat.Chat;
 import com.nimble.server_spring.modules.chat.ChatType;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class ChatResponseDto {
 
     private Long chatId;
-    private Long memberId;
+    private Long meetUserId;
     private String email;
     private LocalDateTime createdAt;
     private ChatType chatType;
@@ -22,14 +21,14 @@ public class ChatResponseDto {
     @Builder
     public ChatResponseDto(
         Long chatId,
-        Long memberId,
+        Long meetUserId,
         String email,
         LocalDateTime createdAt,
         ChatType chatType,
         String message
     ) {
         this.chatId = chatId;
-        this.memberId = memberId;
+        this.meetUserId = meetUserId;
         this.email = email;
         this.createdAt = createdAt;
         this.chatType = chatType;
@@ -40,8 +39,8 @@ public class ChatResponseDto {
         return ChatResponseDto.builder()
             .createdAt(chat.getCreatedAt())
             .chatType(chat.getChatType())
-            .email(chat.getMeetMember().getUser().getEmail())
-            .memberId(chat.getMeetMember().getId())
+            .email(chat.getMeetUser().getUser().getEmail())
+            .meetUserId(chat.getMeetUser().getId())
             .message(chat.getMessage())
             .build();
     }

--- a/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
@@ -39,7 +39,7 @@ public class Meet extends BaseEntity {
 
     @OneToMany(mappedBy = "meet", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @NotNull
-    private List<MeetMember> meetMembers = new ArrayList<>();
+    private List<MeetUser> meetUsers = new ArrayList<>();
 
     @Builder
     public Meet(String meetName, String description, User host) {
@@ -52,13 +52,13 @@ public class Meet extends BaseEntity {
         return this.host.getId().equals(user.getId());
     }
 
-    public Optional<MeetMember> findMember(Long memberId) {
-        return this.meetMembers.stream()
-            .filter(meetMember -> meetMember.getId().equals(memberId))
+    public Optional<MeetUser> findMeetUser(Long meetUserId) {
+        return this.meetUsers.stream()
+            .filter(meetUser -> meetUser.getId().equals(meetUserId))
             .findFirst();
     }
 
-    public void addMeetMember(MeetMember meetMember) {
-        this.meetMembers.add(meetMember);
+    public void addMeetUser(MeetUser meetUser) {
+        this.meetUsers.add(meetUser);
     }
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/Meet.java
@@ -32,24 +32,27 @@ public class Meet extends BaseEntity {
     @Length(max = 48)
     private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "host_id")
-    @NotNull
-    private User host;
-
     @OneToMany(mappedBy = "meet", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @NotNull
     private List<MeetUser> meetUsers = new ArrayList<>();
 
     @Builder
-    public Meet(String meetName, String description, User host) {
+    public Meet(String meetName, String description) {
         this.meetName = meetName;
         this.description = description;
-        this.host = host;
     }
 
-    public boolean isHost(User user) {
-        return this.host.getId().equals(user.getId());
+    public boolean isHostedBy(User user) {
+        return this.meetUsers.stream()
+            .filter(meetUser -> meetUser.getUser().getId().equals(user.getId()))
+            .findFirst()
+            .map(MeetUser::isHost)
+            .orElse(false);
+    }
+
+    public boolean isParticipatedBy(User user) {
+        return this.meetUsers.stream()
+            .anyMatch(meetUser -> meetUser.getUser().getId().equals(user.getId()));
     }
 
     public Optional<MeetUser> findMeetUser(Long meetUserId) {

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetController.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetController.java
@@ -48,7 +48,7 @@ public class MeetController {
     public ResponseEntity<List<MeetResponseDto>> getMeets(Principal principal) {
         User currentUser = userService.getUserByPrincipalLazy(principal);
 
-        List<Meet> meetList = meetRepository.findHostedOrInvitedMeetsByUserId(currentUser.getId());
+        List<Meet> meetList = meetRepository.findParticipatedMeets(currentUser.getId());
         List<MeetResponseDto> meetResponseDtoList = meetList.stream()
             .map(MeetResponseDto::fromMeet)
             .toList();
@@ -77,7 +77,8 @@ public class MeetController {
     @GetMapping("/{meetId}")
     @Operation(summary = "미팅 조회", description = "특정 미팅을 조회합니다.")
     @ApiErrorCodes({
-        ErrorCode.MEET_NOT_FOUND
+        ErrorCode.MEET_NOT_FOUND,
+        ErrorCode.NOT_MEET_USER_FORBIDDEN
     })
     public ResponseEntity<MeetResponseDto> getMeet(
         @PathVariable @Parameter(description = "조회할 미팅의 ID", required = true)
@@ -86,8 +87,12 @@ public class MeetController {
     ) {
         User currentUser = userService.getUserByPrincipalLazy(principal);
 
-        Meet meet = meetRepository.findMeetByIdIfHostedOrInvited(meetId, currentUser.getId())
+        Meet meet = meetRepository.findMeetById(meetId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
+
+        if (!meet.isParticipatedBy(currentUser)) {
+            throw new ErrorCodeException(ErrorCode.NOT_MEET_USER_FORBIDDEN);
+        }
 
         return new ResponseEntity<>(
             MeetResponseDto.fromMeet(meet),
@@ -98,7 +103,11 @@ public class MeetController {
     @PostMapping("/{meetId}/member")
     @Operation(summary = "멤버 초대", description = "email에 해당하는 사용자를 특정 미팅에 초대합니다.")
     @ApiErrorCodes({
-        ErrorCode.MEET_NOT_FOUND
+        ErrorCode.MEET_NOT_FOUND,
+        ErrorCode.NOT_MEET_HOST_FORBIDDEN,
+        ErrorCode.MEET_INVITE_LIMIT_OVER,
+        ErrorCode.USER_NOT_FOUND_BY_EMAIL,
+        ErrorCode.USER_ALREADY_INVITED
     })
     public ResponseEntity<MeetUserResponseDto> invite(
         @PathVariable @Parameter(description = "멤버를 초대할 미팅의 ID", required = true)
@@ -124,7 +133,9 @@ public class MeetController {
     @DeleteMapping("/{meetId}/member/{meetUserId}")
     @Operation(summary = "멤버 강퇴", description = "특정 미팅에서 멤버를 강퇴합니다.")
     @ApiErrorCodes({
-        ErrorCode.MEET_NOT_FOUND
+        ErrorCode.MEET_NOT_FOUND,
+        ErrorCode.NOT_MEET_HOST_FORBIDDEN,
+        ErrorCode.MEET_USER_NOT_FOUND
     })
     public ResponseEntity<MeetUserResponseDto> kickOut(
         @PathVariable @Parameter(description = "멤버를 강퇴할 미팅의 ID", required = true)
@@ -150,7 +161,7 @@ public class MeetController {
     @GetMapping("/{meetId}/chat")
     @Operation(summary = "채팅 목록 조회", description = "특정 미팅의 채팅 목록을 조회합니다.")
     @ApiErrorCodes({
-        ErrorCode.NOT_MEET_USER
+        ErrorCode.NOT_MEET_USER_FORBIDDEN
     })
     public ResponseEntity<Slice<ChatResponseDto>> getChats(
         @PathVariable @Parameter(description = "채팅 목록을 조회할 미팅의 ID", required = true)
@@ -166,7 +177,7 @@ public class MeetController {
             currentUser.getId(),
             meetId
         )) {
-            throw new ErrorCodeException(ErrorCode.NOT_MEET_USER);
+            throw new ErrorCodeException(ErrorCode.NOT_MEET_USER_FORBIDDEN);
         }
 
         Slice<ChatResponseDto> chatResponsDtoSlice = chatRepository.findAllByMeetId(

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepository.java
@@ -8,6 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface MeetRepository extends JpaRepository<Meet, Long>, MeetRepositoryExtension {
 
-    @EntityGraph(attributePaths = {"host", "meetUsers", "meetUsers.user"})
-    Optional<Meet> findDistinctByIdAndHost_Id(Long id, Long hostId);
+    @EntityGraph(attributePaths = {"meetUsers", "meetUsers.user"})
+    Optional<Meet> findMeetById(Long id);
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepository.java
@@ -8,6 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface MeetRepository extends JpaRepository<Meet, Long>, MeetRepositoryExtension {
 
-    @EntityGraph(attributePaths = {"host", "meetMembers", "meetMembers.user"})
+    @EntityGraph(attributePaths = {"host", "meetUsers", "meetUsers.user"})
     Optional<Meet> findDistinctByIdAndHost_Id(Long id, Long hostId);
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtension.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtension.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 public interface MeetRepositoryExtension {
 
-    public List<Meet> findHostedOrInvitedMeetsByUserId(Long userId);
+    public List<Meet> findParticipatedMeets(Long userId);
 
-    public Optional<Meet> findMeetByIdIfHostedOrInvited(Long meetId, Long userId);
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtensionImpl.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtensionImpl.java
@@ -16,53 +16,24 @@ public class MeetRepositoryExtensionImpl implements MeetRepositoryExtension {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Meet> findHostedOrInvitedMeetsByUserId(Long userId) {
+    public List<Meet> findParticipatedMeets(Long userId) {
         QMeet meet = QMeet.meet;
-        QUser host = QUser.user;
+        QUser user = QUser.user;
         QMeetUser meetUser = QMeetUser.meetUser;
-        QUser member = new QUser("member");
 
         return jpaQueryFactory.selectFrom(meet)
-            .leftJoin(meet.host, host)
+            .join(meet.meetUsers, meetUser)
             .fetchJoin()
-            .leftJoin(meet.meetUsers, meetUser)
+            .join(meetUser.user, user)
             .fetchJoin()
-            .leftJoin(meetUser.user, member)
-            .fetchJoin()
-
             .where(meet.id.in(
-                    JPAExpressions
-                        .select(meet.id)
+                    JPAExpressions.selectDistinct(meet.id)
                         .from(meet)
-                        .where(
-                            meet.host.id.eq(userId)
-                                .or(member.id.eq(userId))
-                        )
+                        .join(meet.meetUsers, meetUser)
+                        .join(meetUser.user, user)
+                        .where(user.id.eq(userId))
                 )
             )
             .fetch();
-    }
-
-    @Override
-    public Optional<Meet> findMeetByIdIfHostedOrInvited(Long meetId, Long userId) {
-        QMeet meet = QMeet.meet;
-        QUser host = QUser.user;
-        QMeetUser meetUser = QMeetUser.meetUser;
-        QUser member = new QUser("member");
-
-        Meet fetchedMeet = jpaQueryFactory.selectFrom(meet)
-            .leftJoin(meet.host, host)
-            .fetchJoin()
-            .leftJoin(meet.meetUsers, meetUser)
-            .fetchJoin()
-            .leftJoin(meetUser.user, member)
-            .fetchJoin()
-            .where(meet.id.eq(meetId)
-                .and(host.id.eq(userId)
-                    .or(member.id.eq(userId))
-                )
-            )
-            .fetchOne();
-        return Optional.ofNullable(fetchedMeet);
     }
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtensionImpl.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetRepositoryExtensionImpl.java
@@ -19,15 +19,15 @@ public class MeetRepositoryExtensionImpl implements MeetRepositoryExtension {
     public List<Meet> findHostedOrInvitedMeetsByUserId(Long userId) {
         QMeet meet = QMeet.meet;
         QUser host = QUser.user;
-        QMeetMember meetMember = QMeetMember.meetMember;
+        QMeetUser meetUser = QMeetUser.meetUser;
         QUser member = new QUser("member");
 
         return jpaQueryFactory.selectFrom(meet)
             .leftJoin(meet.host, host)
             .fetchJoin()
-            .leftJoin(meet.meetMembers, meetMember)
+            .leftJoin(meet.meetUsers, meetUser)
             .fetchJoin()
-            .leftJoin(meetMember.user, member)
+            .leftJoin(meetUser.user, member)
             .fetchJoin()
 
             .where(meet.id.in(
@@ -47,15 +47,15 @@ public class MeetRepositoryExtensionImpl implements MeetRepositoryExtension {
     public Optional<Meet> findMeetByIdIfHostedOrInvited(Long meetId, Long userId) {
         QMeet meet = QMeet.meet;
         QUser host = QUser.user;
-        QMeetMember meetMember = QMeetMember.meetMember;
+        QMeetUser meetUser = QMeetUser.meetUser;
         QUser member = new QUser("member");
 
         Meet fetchedMeet = jpaQueryFactory.selectFrom(meet)
             .leftJoin(meet.host, host)
             .fetchJoin()
-            .leftJoin(meet.meetMembers, meetMember)
+            .leftJoin(meet.meetUsers, meetUser)
             .fetchJoin()
-            .leftJoin(meetMember.user, member)
+            .leftJoin(meetUser.user, member)
             .fetchJoin()
             .where(meet.id.eq(meetId)
                 .and(host.id.eq(userId)

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetService.java
@@ -25,7 +25,6 @@ public class MeetService {
         Meet meet = Meet.builder()
             .meetName(meetCreateRequestDto.getMeetName())
             .description(meetCreateRequestDto.getDescription())
-            .host(user)
             .build();
 
         MeetUser meetUser = MeetUser.builder()
@@ -43,8 +42,12 @@ public class MeetService {
         Long meetId,
         MeetInviteRequestDto meetInviteRequestDto
     ) {
-        Meet meet = meetRepository.findDistinctByIdAndHost_Id(meetId, currentUser.getId())
+        Meet meet = meetRepository.findMeetById(meetId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
+
+        if (!meet.isHostedBy(currentUser)) {
+            throw new ErrorCodeException(ErrorCode.NOT_MEET_HOST_FORBIDDEN);
+        }
 
         if (meet.getMeetUsers().size() >= INVITE_LIMIT_NUMBER) {
             throw new ErrorCodeException(ErrorCode.MEET_INVITE_LIMIT_OVER);
@@ -71,8 +74,12 @@ public class MeetService {
     }
 
     public MeetUser kickOut(User currentUser, Long meetId, Long meetUserId) {
-        Meet meet = meetRepository.findDistinctByIdAndHost_Id(meetId, currentUser.getId())
+        Meet meet = meetRepository.findMeetById(meetId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_NOT_FOUND));
+
+        if (!meet.isHostedBy(currentUser)) {
+            throw new ErrorCodeException(ErrorCode.NOT_MEET_HOST_FORBIDDEN);
+        }
 
         MeetUser meetUser = meet.findMeetUser(meetUserId)
             .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEET_USER_NOT_FOUND));

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetUser.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetUser.java
@@ -1,5 +1,6 @@
 package com.nimble.server_spring.modules.meet;
 
+import com.nimble.server_spring.infra.persistence.BaseEntity;
 import com.nimble.server_spring.infra.persistence.BooleanToYNConverter;
 import com.nimble.server_spring.modules.user.User;
 import jakarta.persistence.*;
@@ -15,21 +16,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @ToString(of = {"id", "meetUserRole", "isEntered"})
-public class MeetUser {
+public class MeetUser extends BaseEntity {
 
     @Id
     @GeneratedValue
     private Long id;
-
-    @NotNull
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @NotNull
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meet_id")

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetUser.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetUser.java
@@ -56,6 +56,10 @@ public class MeetUser {
         this.meetUserRole = meetUserRole;
     }
 
+    public boolean isHost() {
+        return this.meetUserRole == MeetUserRole.HOST;
+    }
+
     public void enterMeet() {
         this.isEntered = true;
     }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetUser.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetUser.java
@@ -16,8 +16,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@ToString(of = {"id", "memberRole", "isEntered"})
-public class MeetMember {
+@ToString(of = {"id", "meetUserRole", "isEntered"})
+public class MeetUser {
 
     @Id
     @GeneratedValue
@@ -43,17 +43,17 @@ public class MeetMember {
 
     @Enumerated(EnumType.STRING)
     @NotNull
-    private MemberRole memberRole;
+    private MeetUserRole meetUserRole;
 
     @Convert(converter = BooleanToYNConverter.class)
     @NotNull
     private boolean isEntered = false;
 
     @Builder
-    public MeetMember(Meet meet, User user, MemberRole memberRole) {
+    public MeetUser(Meet meet, User user, MeetUserRole meetUserRole) {
         this.meet = meet;
         this.user = user;
-        this.memberRole = memberRole;
+        this.meetUserRole = meetUserRole;
     }
 
     public void enterMeet() {

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetUserRepository.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetUserRepository.java
@@ -5,9 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public interface MeetMemberRepository extends JpaRepository<MeetMember, Long> {
+public interface MeetUserRepository extends JpaRepository<MeetUser, Long> {
 
-    Optional<MeetMember> findByUserIdAndMeetId(Long userId, Long meetId);
+    Optional<MeetUser> findByUserIdAndMeetId(Long userId, Long meetId);
 
     boolean existsByUser_IdAndMeet_Id(Long userId, Long meetId);
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/MeetUserRole.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/MeetUserRole.java
@@ -1,5 +1,5 @@
 package com.nimble.server_spring.modules.meet;
 
-public enum MemberRole {
+public enum MeetUserRole {
     HOST, MEMBER
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/dto/response/MeetResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/dto/response/MeetResponseDto.java
@@ -29,9 +29,6 @@ public class MeetResponseDto {
     @Schema(example = "2023-01-01T00:00:00", description = "미팅 생성 시간")
     private LocalDateTime createdAt;
 
-    @Schema(description = "미팅 생성 유저 정보")
-    private SimpleUserResponseDto host;
-
     @Schema(description = "미팅 멤버 정보의 목록")
     private List<MeetUserResponseDto> meetUsers;
 
@@ -41,7 +38,6 @@ public class MeetResponseDto {
             .meetName(meet.getMeetName())
             .description(meet.getDescription())
             .createdAt(meet.getCreatedAt())
-            .host(SimpleUserResponseDto.fromUser(meet.getHost()))
             .meetUsers(meet.getMeetUsers().stream()
                 .map(MeetUserResponseDto::fromMeetUser)
                 .toList()

--- a/src/main/java/com/nimble/server_spring/modules/meet/dto/response/MeetResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/dto/response/MeetResponseDto.java
@@ -17,35 +17,35 @@ import java.util.List;
 @Builder
 public class MeetResponseDto {
 
-  @Schema(example = "1", description = "미팅 ID")
-  private Long id;
+    @Schema(example = "1", description = "미팅 ID")
+    private Long id;
 
-  @Schema(example = "MyMeet", description = "미팅 이름")
-  private String meetName;
+    @Schema(example = "MyMeet", description = "미팅 이름")
+    private String meetName;
 
-  @Schema(example = "예시 미팅 입니다.", description = "미팅 설명")
-  private String description;
+    @Schema(example = "예시 미팅 입니다.", description = "미팅 설명")
+    private String description;
 
-  @Schema(example = "2023-01-01T00:00:00", description = "미팅 생성 시간")
-  private LocalDateTime createdAt;
+    @Schema(example = "2023-01-01T00:00:00", description = "미팅 생성 시간")
+    private LocalDateTime createdAt;
 
-  @Schema(description = "미팅 생성 유저 정보")
-  private SimpleUserResponseDto host;
+    @Schema(description = "미팅 생성 유저 정보")
+    private SimpleUserResponseDto host;
 
-  @Schema(description = "미팅 멤버 정보의 목록")
-  private List<MemberResponseDto> members;
+    @Schema(description = "미팅 멤버 정보의 목록")
+    private List<MeetUserResponseDto> meetUsers;
 
-  public static MeetResponseDto fromMeet(Meet meet) {
-    return MeetResponseDto.builder()
-        .id(meet.getId())
-        .meetName(meet.getMeetName())
-        .description(meet.getDescription())
-        .createdAt(meet.getCreatedAt())
-        .host(SimpleUserResponseDto.fromUser(meet.getHost()))
-        .members(meet.getMeetMembers().stream()
-            .map(MemberResponseDto::fromMeetMember)
-            .toList()
-        )
-        .build();
-  }
+    public static MeetResponseDto fromMeet(Meet meet) {
+        return MeetResponseDto.builder()
+            .id(meet.getId())
+            .meetName(meet.getMeetName())
+            .description(meet.getDescription())
+            .createdAt(meet.getCreatedAt())
+            .host(SimpleUserResponseDto.fromUser(meet.getHost()))
+            .meetUsers(meet.getMeetUsers().stream()
+                .map(MeetUserResponseDto::fromMeetUser)
+                .toList()
+            )
+            .build();
+    }
 }

--- a/src/main/java/com/nimble/server_spring/modules/meet/dto/response/MeetUserResponseDto.java
+++ b/src/main/java/com/nimble/server_spring/modules/meet/dto/response/MeetUserResponseDto.java
@@ -1,7 +1,6 @@
 package com.nimble.server_spring.modules.meet.dto.response;
 
-import com.nimble.server_spring.modules.meet.MeetMember;
-import com.nimble.server_spring.modules.meet.MemberRole;
+import com.nimble.server_spring.modules.meet.MeetUser;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class MemberResponseDto {
+public class MeetUserResponseDto {
 
     @Schema(example = "1", description = "미팅 멤버 ID")
     private Long id;
@@ -26,12 +25,12 @@ public class MemberResponseDto {
     @Schema(example = "MEMBER", description = "미팅 멤버의 권한")
     private String role;
 
-    public static MemberResponseDto fromMeetMember(MeetMember meetMember) {
-        return MemberResponseDto.builder()
-                .id(meetMember.getId())
-                .email(meetMember.getUser().getEmail())
-                .nickname(meetMember.getUser().getNickname())
-                .role(meetMember.getMemberRole().name())
-                .build();
+    public static MeetUserResponseDto fromMeetUser(MeetUser meetUser) {
+        return MeetUserResponseDto.builder()
+            .id(meetUser.getId())
+            .email(meetUser.getUser().getEmail())
+            .nickname(meetUser.getUser().getNickname())
+            .role(meetUser.getMeetUserRole().name())
+            .build();
     }
 }


### PR DESCRIPTION
- [x] Meet - User의 중간 테이블 및 엔티티 이름을 MeetUser로 변경
    - 기존의 MeetMember는 크게 의미를 나타내지 못한다고 판단, 두 테이블 명을 결합한 이름으로 변경
- [x] Meet, User 간의 이중 관계를 제거, 다대다 관계 하나로 풀어내도록 수정
    - [x] Meet의 host 프로퍼티를 통한 User 참조 제거, MeetUser 내의 role 프로퍼티로 미팅 참여자의 권한 확인
    - [x] 참여한 미팅 목록을 조회하는 쿼리를 새로운 구조에 맞춰서 변경
    - [x] 각 에러 상황에 대한 에러 코드/메시지 명세화
- [x] 채팅 시 유저 인증 불가능한 버그 수정
    - principal에 userId가 들어가도록 변경된 이력이 존재
    - UserService에 구현해 둔 getUserByPrincipalLazy() 메서드를 사용하도록 수정